### PR TITLE
修正:山の一覧ページのレイアウト修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11204,7 +11204,7 @@ body {
   background-attachment: scroll;
   background-size: cover;
 }
-.searchform-section .form-search input {
+.searchform-section .form-search input, .searchform-section .form-search select {
   box-shadow: 0 0.1875rem 0.1875rem 0 rgba(0, 0, 0, 0.1) !important;
   padding: 1.25rem 2rem;
   height: auto;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
   end
 
   def search_params
-    params[:q]&.permit(:name_or_name_en_cont)
+    params[:q]&.permit(:name_or_name_en_cont, :prefecture_code_eq)
   end
 end

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -52,7 +52,7 @@
                     <div class="col-md-6 col-lg-3 mb-5">
                         <div class="portfolio-item-caption d-flex align-items-center justify-content-center">
                             <div class="portfolio-item-caption-content text-center text-white">
-                                <%= link_to mountains_path(area: area), class: 'btn btn-outline-primary' do %>
+                                <%= link_to mountains_path(area: area), class: 'btn btn-outline-primary', 'data-turbolinks': false do %>
                                     <%= add_space(area) %>
                                 <% end %>
                             </div>                    

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <!-- セキュリティ関連-->
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <!-- アセットパイプライン-->
+    <!-- turbolinks-->
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/app/views/mountains/_mountain.html.erb
+++ b/app/views/mountains/_mountain.html.erb
@@ -1,11 +1,14 @@
 <div class="col-lg-4 col-sm-6 mb-4">
     <div class="portfolio-item">
-        <%= link_to mountain_path(mountain) do %>
+        <%= link_to mountain_path(mountain), 'data-turbolinks': false do %>
             <%= image_tag mountain.image.url, class: 'img-fluid rounded-top' %>
         <% end %>
         <div class="portfolio-caption rounded-bottom">
-            <%= link_to mountain_path(mountain) do %>
-                <div class="portfolio-caption-heading"><%= mountain.name %> (<%= mountain.pref.name %>)</div>
+            <%= link_to mountain_path(mountain), 'data-turbolinks': false do %>
+                <div class="portfolio-caption-heading">
+                <h4 class="text-truncate d-inline"><%= mountain.name %></h4>
+                <p class="text-truncate d-inline">(<%= mountain.pref.name %>)</p>
+                </div>
             <% end %>
         </div>
     </div>

--- a/app/views/mountains/index.html.erb
+++ b/app/views/mountains/index.html.erb
@@ -3,8 +3,8 @@
   <div class="container px-4 px-lg-5">
       <div class="row gx-4 gx-lg-5">
           <div class="col-md-10 col-lg-8 mx-auto text-center">
-              <form class="form-search" id="contactForm">
-                  <div class="row input-group-newsletter">
+              <form class="form-search">
+                  <div class="row">
                       <%= render 'shared/search_form', q: @q, url: mountains_path %>
                   </div>
               </form>
@@ -17,7 +17,11 @@
 <section class="page-section bg-light" id="portfolio">
     <div class="container px-4 px-lg-5">
         <div class="row">
-            <%= render @mountains %>
+            <% if @mountains.present? %>
+                <%= render @mountains %>
+            <% else %>
+                <h2>検索条件と一致する結果が見つかりませんでした。<h2>
+            <% end %>
         </div>
         <%= paginate @mountains %>
     </div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,6 +1,9 @@
 <%= search_form_for q, url: url do |f| %>
   <div class="col">
-      <%= f.search_field :name_or_name_en_cont, class: "form-control", placeholder: "キーワード" %>
+      <%= f.search_field :name_or_name_en_cont, method: :get, local: true, class: "form-control", placeholder: "キーワード" %>
+  </div>
+  <div class="col-3">
+      <%= f.collection_select :prefecture_code_eq, JpPrefecture::Prefecture.all, :code, :name, { include_blank: '都道府県を選択' }, { class: 'form-control' } %>
   </div>
   <div class="col-auto">
       <%= f.submit '検索', class: "col-auto btn btn-primary"%>


### PR DESCRIPTION
## 概要

山の一覧ページにてcssの修正を行なった。
- 各mountainの表示名のサイズ修正
- ページ遷移時のturbolinksの無効化

## 影響範囲

特になし

## コメント

turbolinksが有効になっているので、scriptタグが読み込まれず正しく表示されないなどページ遷移時に問題が発生している。
コードとしてはscriptタグをかなり冗長に描いているので、コード整理する必要があるがその際にturbolinksの挙動も確認する必要がある。

#58 
