### PR TITLE
追加:山テーブルにlevelカラムを追加

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,5 @@
 class Course < ApplicationRecord
   belongs_to :mountain
 
-  enum level: { easy: 0, normal: 1, hard: 2, very_hard: 3 }
+  enum level: { easy: 0, normal: 1, hard: 2 }
 end

--- a/app/views/mountains/_mountain.html.erb
+++ b/app/views/mountains/_mountain.html.erb
@@ -3,7 +3,7 @@
         <%= link_to mountain_path(mountain), 'data-turbolinks': false do %>
             <%= image_tag mountain.image.url, class: 'img-fluid rounded-top' %>
         <% end %>
-        <div class="portfolio-caption rounded-bottom">
+        <div class="portfolio-caption rounded-bottom shadow-sm">
             <%= link_to mountain_path(mountain), 'data-turbolinks': false do %>
                 <div class="portfolio-caption-heading">
                 <h4 class="text-truncate d-inline"><%= mountain.name %></h4>

--- a/app/views/mountains/show.html.erb
+++ b/app/views/mountains/show.html.erb
@@ -13,7 +13,9 @@
                     <hr class="mb-4 mx-auto" />
                     <p class="text-black-50 mb-0">標　高：<%= @mountain.elevation %>m</p>
                     <p class="text-black-50 mb-0">エリア：<%= @mountain.pref.name %> <%= @mountain.city %></p>
-                    <p class="text-black-50 mb-0">難易度</p>
+                    <% if @mountain.level.present? %>
+                        <p class="text-black-50 mb-0">難易度：<%= @mountain.level %></p>
+                    <% end %>
                 </div>
             </div>
         </div>

--- a/db/migrate/20210806023402_add_level_to_mountains.rb
+++ b/db/migrate/20210806023402_add_level_to_mountains.rb
@@ -1,0 +1,5 @@
+class AddLevelToMountains < ActiveRecord::Migration[6.0]
+  def change
+    add_column :mountains, :level, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_103018) do
+ActiveRecord::Schema.define(version: 2021_08_06_023402) do
 
   create_table "courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2021_07_22_103018) do
     t.string "image"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "level"
   end
 
   create_table "outfits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/mountain_level.html
+++ b/mountain_level.html
@@ -1,0 +1,1562 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="verify-v1" content="vZwyHF9B4uT+SswJOF4JQB2ZwGKP6DrPoZdNookXysw=" >
+<meta name="keywords" content="難易度順,日本百名山,一覧表,登山">
+<meta name="description" content="日本百名山を「難易度順」で一覧表にしたものです。この一覧表には「難易度」「定数（体力度）」「参考日程」「エリア」「標高」が含まれています">
+<base href="https://www.momonayama.net/">
+<link rel="shortcut icon" href="favicon.ico">
+
+<link rel="stylesheet" href="css/bas202103112.css">
+<!--JavaScript-->
+<script src="js/contents/sp_menu_control_v3.js" charset="utf-8"></script>
+<!--Ads by Google-->
+<script data-ad-client="ca-pub-8903398808176240" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<title>難易度順 日本百名山 一覧表</title>
+</head>
+<body>
+<!--↓バック↓-->
+<div class="back">
+	<!--↓ヘッダー↓-->
+	<header>
+	<!--↓タイトル画像↓-->
+	<div class="topimgbox">
+		<a href="index.html"><img class="toptitle" src="gazo/title/top.png" alt="日本百名山登山支援 全頂制覇百名山" title="日本百名山登山支援 全頂制覇百名山"></a>
+	</div>
+	<!--↑タイトル画像↑-->
+	</header>
+	<!--↑ヘッダー↑-->
+	<!--↓メイン↓-->
+	<main>
+	<article>
+	<!--↓ミドルボックス↓-->
+	<div class="middlebox">
+		<!--↓メインカラム↓-->
+		<div class="maincolumn">
+			<!--↓検索ボックス↓-->
+			<nav>
+			<div class="searchsp1">
+				<script async src="https://cse.google.com/cse.js?cx=partner-pub-8903398808176240:nnafynj36qt"></script>
+				<div class="gcse-search">
+					<p class="searchin">
+						山で捨てちゃいけないものは「ゴミと<span class="red">命</span>」<br>
+						&gt;&gt;&gt; サイト内検索読み込み中 &lt;&lt;&lt;
+					</p>
+				</div>
+			</div>
+			</nav>
+			<!--↑検索ボックス↑-->
+			<!--↓ページタイトル↓-->
+			<div class="htit1">
+				<h1>
+					難易度順 日本百名山 一覧表
+				</h1>
+			</div>
+			<!--↑ページタイトル↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addsp1">
+				<!--全頂 SP トップ-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="2781035807"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓サイト告知↓-->
+			<aside>
+			<p class="con4">
+				<a href="https://kanto-fureai.net/">
+					ウォーキングコース、ハイキングコース、登山コースなどのバリエーションに富んだ「関東ふれあいの道（首都圏自然歩道）」の完全踏破を応援するサイトをリリースしました
+				</a>
+			</p>
+			<aside>
+			</aside>
+			<p class="con4">
+				<a href="https://34navi.net/">
+					秩父の観光旅行におすすめの、日本百番観音に数えられる「秩父三十四ヶ所観音霊場」の秩父札所巡り（お遍路）をサポートするサイトをリリースしました
+				</a>
+			</p>
+			</aside>
+			<!--↑サイト告知↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addpc1">
+				<!--全頂 PC トップ-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="1994522611"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓トップメニュー↓-->
+			<nav>
+			<div class="mainmenu1">
+				<a class="bttlink1" href="hundred_mt_list_data/list.html">日本百名山 一覧</a>
+				<a class="bttlink1" href="hundred_mt_list_data/japanese_syllabary.html">五十音順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/sea_level.html">標高順</a>
+				<div class="bttlink1">難易度順</div>
+				<a class="bttlink1" href="hundred_mt_list_data/stamina.html">体力度順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/course_time.html">参考タイム順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/itinerary.html">参考日程順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/season.html">登山適期順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/colored_leaves.html">紅葉時期順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/snow_season.html">積雪期・残雪期 一覧</a>
+				<a class="bttlink1" href="hundred_mt_list_data/volcano.html">活火山指定 一覧</a>
+			</div>
+			</nav>
+			<!--↑トップメニュー↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addsp1">
+				<!-- 全頂 SP トップメニュー下 -->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="7342148253"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<div class="htit2">
+				<h2>
+					新基準版
+				</h2>
+			</div>
+			<p class="con3">
+				この表の<span class="red">「難易度」「定数（体力度）」「参考日程」は、山と渓谷社発行「日本山岳協会編 新版 日本三百名山 登山ガイド」にて紹介されているモデルコースに基づくものです</span>。複数の登山コースがある場合、その全てのコースの「難易度」「定数（体力度）」「参考日程」を示すものではありません
+			</p>
+			<div class="htit10"><div>
+				<h3 class="cen">
+					難易度順 一覧表
+				</h3>
+			</div></div>
+			<p class="sctate">（この表は横にスクロールできます）</p>
+			<div class="tacon1">
+				<table>
+					<colgroup><col class="top" span="1"></colgroup>
+					<colgroup><col class="nam" span="1"></colgroup>
+					<colgroup><col class="dif" span="1"></colgroup>
+					<colgroup><col class="sta" span="1"></colgroup>
+					<colgroup><col class="iti" span="1"></colgroup>
+					<colgroup><col class="are" span="1"></colgroup>
+					<colgroup><col class="sea" span="1"></colgroup>
+					<thead>
+						<tr>
+							<th>No.</th>
+							<th>山名</th>
+							<th>難易度<br>(5段階)</th>
+							<th>定数<br>(体力度)</th>
+							<th>参考日程</th>
+							<th>エリア</th>
+							<th>標高</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>012</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-012.html">八幡平</a></td>
+							<td>★★</td>
+							<td>16</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1613m</td>
+						</tr>
+						<tr>
+							<td>014</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-014.html">早池峰山</a></td>
+							<td>★★</td>
+							<td>19</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1917m</td>
+						</tr>
+						<tr>
+							<td>011</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-011.html">八甲田山</a></td>
+							<td>★★</td>
+							<td>20</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1585m</td>
+						</tr>
+						<tr>
+							<td>004</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-004.html">阿寒岳</a></td>
+							<td>★★</td>
+							<td>27</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>1499m</td>
+						</tr>
+						<tr>
+							<td>003</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-003.html">斜里岳</a></td>
+							<td>★★★</td>
+							<td>29</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>1547m</td>
+						</tr>
+						<tr>
+							<td>005</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-005.html">大雪山</a></td>
+							<td>★★★</td>
+							<td>30</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>2290m</td>
+						</tr>
+						<tr>
+							<td>010</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-010.html">岩木山</a></td>
+							<td>★★★</td>
+							<td>32</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1625m</td>
+						</tr>
+						<tr>
+							<td>001</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-001.html">利尻岳</a></td>
+							<td>★★★</td>
+							<td>37</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>1719m</td>
+						</tr>
+						<tr>
+							<td>013</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-013.html">岩手山</a></td>
+							<td>★★★</td>
+							<td>37</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>2038m</td>
+						</tr>
+						<tr>
+							<td>002</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-002.html">羅臼岳</a></td>
+							<td>★★★</td>
+							<td>39</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>1661m</td>
+						</tr>
+						<tr>
+							<td>007</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-007.html">十勝岳</a></td>
+							<td>★★★</td>
+							<td>40</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>2077m</td>
+						</tr>
+						<tr>
+							<td>009</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-009.html">後方羊蹄山</a></td>
+							<td>★★★</td>
+							<td>42</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>1898m</td>
+						</tr>
+						<tr>
+							<td>006</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-006.html">トムラウシ山</a></td>
+							<td>★★★</td>
+							<td>67</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>2141m</td>
+						</tr>
+						<tr>
+							<td>008</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-008.html">幌尻岳</a></td>
+							<td>★★★★</td>
+							<td>64</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/hokkaido.html">北海道</a></td>
+							<td>2052m</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addpc1">
+				<!--全頂 PC コンテンツ 1-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="7264300069"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addsp1">
+				<!--全頂 SP コンテンツ 1-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="1814898464"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<div class="htit2">
+				<h2>
+					旧基準版
+				</h2>
+			</div>
+			<p class="con3">
+				この表の<span class="red">「難易度」「体力度」「参考日程」は、山と渓谷社発行「決定版 日本百名山 登山ガイド」にて紹介されているモデルコースに基づくものです</span>。複数の登山コースがある場合、その全てのコースの「難易度」「体力度」「参考日程」を示すものではありません
+			</p>
+			<div class="htit10"><div>
+				<h3 class="cen">
+					難易度順 一覧表（☆）
+				</h3>
+			</div></div>
+			<p class="sctate">（この表は横にスクロールできます）</p>
+			<div class="tacon1">
+				<table>
+					<colgroup><col class="top" span="1"></colgroup>
+					<colgroup><col class="nam" span="1"></colgroup>
+					<colgroup><col class="dif" span="1"></colgroup>
+					<colgroup><col class="sta" span="1"></colgroup>
+					<colgroup><col class="iti" span="1"></colgroup>
+					<colgroup><col class="are" span="1"></colgroup>
+					<colgroup><col class="sea" span="1"></colgroup>
+					<thead>
+						<tr>
+							<th>No.</th>
+							<th>山名</th>
+							<th>難易度<br>(3段階)</th>
+							<th>体力度<br>(3段階)</th>
+							<th>参考日程</th>
+							<th>エリア</th>
+							<th>標高</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>018</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-018.html">蔵王山</a></td>
+							<td>☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1841m</td>
+						</tr>
+						<tr>
+							<td>025</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-025.html">筑波山</a></td>
+							<td>☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">北関東</a></td>
+							<td>877m</td>
+						</tr>
+						<tr>
+							<td>068</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-068.html">乗鞍岳</a></td>
+							<td>☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>3026m</td>
+						</tr>
+						<tr>
+							<td>070</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-070.html">霧ヶ峰</a></td>
+							<td>☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">霧ヶ峰</a></td>
+							<td>1925m</td>
+						</tr>
+						<tr>
+							<td>090</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-090.html">大台ヶ原山</a></td>
+							<td>☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">近畿</a></td>
+							<td>1695m</td>
+						</tr>
+						<tr>
+							<td>099</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-099.html">開聞岳</a></td>
+							<td>☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/kyusyu.html">九州</a></td>
+							<td>922m</td>
+						</tr>
+						<tr>
+							<td>042</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-042.html">草津白根山</a></td>
+							<td>☆</td>
+							<td>☆</td>
+							<td>前夜泊1日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2165m</td>
+						</tr>
+						<tr>
+							<td>029</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-029.html">赤城山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">上州</a></td>
+							<td>1828m</td>
+						</tr>
+						<tr>
+							<td>069</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-069.html">美ヶ原</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">美ヶ原</a></td>
+							<td>2034m</td>
+						</tr>
+						<tr>
+							<td>076</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-076.html">恵那山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">中央アルプス</a></td>
+							<td>2191m</td>
+						</tr>
+						<tr>
+							<td>092</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-092.html">大山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">中国</a></td>
+							<td>1709m</td>
+						</tr>
+						<tr>
+							<td>093</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-093.html">剣山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">四国</a></td>
+							<td>1955m</td>
+						</tr>
+						<tr>
+							<td>098</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-098.html">霧島山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/kyusyu.html">九州</a></td>
+							<td>1700m</td>
+						</tr>
+						<tr>
+							<td>035</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-035.html">巻機山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>前夜泊日帰り</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>1967m</td>
+						</tr>
+						<tr>
+							<td>044</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-044.html">浅間山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>前夜泊1日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2568m</td>
+						</tr>
+						<tr>
+							<td>053</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-053.html">天城山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>前夜泊1日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">南関東</a></td>
+							<td>1406m</td>
+						</tr>
+						<tr>
+							<td>049</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-049.html">雲取山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">奥秩父</a></td>
+							<td>2017m</td>
+						</tr>
+						<tr>
+							<td>050</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-050.html">大菩薩嶺</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">奥秩父</a></td>
+							<td>2057m</td>
+						</tr>
+						<tr>
+							<td>071</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-071.html">蓼科山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">蓼科山</a></td>
+							<td>2530m</td>
+						</tr>
+						<tr>
+							<td>095</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-095.html">九重山</a></td>
+							<td>☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/kyusyu.html">九州</a></td>
+							<td>1787m</td>
+						</tr>
+						<tr>
+							<td>034</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-034.html">平ヶ岳</a></td>
+							<td>☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2141m</td>
+						</tr>
+						<tr>
+							<td>052</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-052.html">富士山</a></td>
+							<td>☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">南関東</a></td>
+							<td>3776m</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addpc1">
+				<!--全頂 PC コンテンツ 2-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="8161410463"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addsp1">
+				<!--全頂 SP コンテンツ 2-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="1975276069"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<div class="htit10"><div>
+				<h3 class="cen">
+					難易度順 一覧表（☆☆）
+				</h3>
+			</div></div>
+			<p class="sctate">（この表は横にスクロールできます）</p>
+			<div class="tacon1">
+				<table>
+					<colgroup><col class="top" span="1"></colgroup>
+					<colgroup><col class="nam" span="1"></colgroup>
+					<colgroup><col class="dif" span="1"></colgroup>
+					<colgroup><col class="sta" span="1"></colgroup>
+					<colgroup><col class="iti" span="1"></colgroup>
+					<colgroup><col class="are" span="1"></colgroup>
+					<colgroup><col class="sea" span="1"></colgroup>
+					<thead>
+						<tr>
+							<th>No.</th>
+							<th>山名</th>
+							<th>難易度<br>(3段階)</th>
+							<th>体力度<br>(3段階)</th>
+							<th>参考日程</th>
+							<th>エリア</th>
+							<th>標高</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>016</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-016.html">月山</a></td>
+							<td>☆☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1980m</td>
+						</tr>
+						<tr>
+							<td>021</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-021.html">安達太良山</a></td>
+							<td>☆☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1700m</td>
+						</tr>
+						<tr>
+							<td>032</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-032.html">皇海山</a></td>
+							<td>☆☆</td>
+							<td>☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">足尾</a></td>
+							<td>2144m</td>
+						</tr>
+						<tr>
+							<td>022</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-022.html">磐梯山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1819m</td>
+						</tr>
+						<tr>
+							<td>030</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-030.html">男体山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">日光</a></td>
+							<td>2486m</td>
+						</tr>
+						<tr>
+							<td>031</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-031.html">日光白根山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">日光</a></td>
+							<td>2578m</td>
+						</tr>
+						<tr>
+							<td>045</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-045.html">両神山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">秩父</a></td>
+							<td>1723m</td>
+						</tr>
+						<tr>
+							<td>067</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-067.html">焼岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2444m</td>
+						</tr>
+						<tr>
+							<td>089</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-089.html">伊吹山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">近畿</a></td>
+							<td>1377m</td>
+						</tr>
+						<tr>
+							<td>094</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-094.html">石鎚山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">四国</a></td>
+							<td>1982m</td>
+						</tr>
+						<tr>
+							<td>097</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-097.html">阿蘇山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/kyusyu.html">九州</a></td>
+							<td>1592m</td>
+						</tr>
+						<tr>
+							<td>036</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-036.html">谷川岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>前夜泊日帰り</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>1963m</td>
+						</tr>
+						<tr>
+							<td>038</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-038.html">雨飾山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>前夜泊日帰り</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>1963m</td>
+						</tr>
+						<tr>
+							<td>043</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-043.html">四阿山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>前夜泊1日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2354m</td>
+						</tr>
+						<tr>
+							<td>047</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-047.html">金峰山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>前夜泊1日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">奥秩父</a></td>
+							<td>2595m</td>
+						</tr>
+						<tr>
+							<td>048</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-048.html">瑞牆山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>前夜泊1日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">奥秩父</a></td>
+							<td>2230m</td>
+						</tr>
+						<tr>
+							<td>015</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-015.html">鳥海山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>2236m</td>
+						</tr>
+						<tr>
+							<td>023</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-023.html">会津駒ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>2132m</td>
+						</tr>
+						<tr>
+							<td>024</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-024.html">那須岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">北関東</a></td>
+							<td>1915m</td>
+						</tr>
+						<tr>
+							<td>026</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-026.html">燧ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">尾瀬</a></td>
+							<td>2356m</td>
+						</tr>
+						<tr>
+							<td>027</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-027.html">至仏山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">尾瀬</a></td>
+							<td>2228m</td>
+						</tr>
+						<tr>
+							<td>039</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-039.html">妙高山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2454m</td>
+						</tr>
+						<tr>
+							<td>040</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-040.html">火打山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2462m</td>
+						</tr>
+						<tr>
+							<td>046</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-046.html">甲武信岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">奥秩父</a></td>
+							<td>2475m</td>
+						</tr>
+						<tr>
+							<td>051</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-051.html">丹沢</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/chichibu_tama_south-kanto.html">南関東</a></td>
+							<td>1567m</td>
+						</tr>
+						<tr>
+							<td>058</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-058.html">立山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>3015m</td>
+						</tr>
+						<tr>
+							<td>059</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-059.html">薬師岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2926m</td>
+						</tr>
+						<tr>
+							<td>065</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-065.html">常念岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2857m</td>
+						</tr>
+						<tr>
+							<td>072</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-072.html">八ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">八ヶ岳</a></td>
+							<td>2899m</td>
+						</tr>
+						<tr>
+							<td>074</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-074.html">木曽駒ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">中央アルプス</a></td>
+							<td>2956m</td>
+						</tr>
+						<tr>
+							<td>077</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-077.html">甲斐駒ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>2967m</td>
+						</tr>
+						<tr>
+							<td>078</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-078.html">仙丈ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>3033m</td>
+						</tr>
+						<tr>
+							<td>087</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-087.html">白山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">北陸</a></td>
+							<td>2702m</td>
+						</tr>
+						<tr>
+							<td>091</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-091.html">大峰山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">近畿</a></td>
+							<td>1915m</td>
+						</tr>
+						<tr>
+							<td>037</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-037.html">苗場山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2145m</td>
+						</tr>
+						<tr>
+							<td>079</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-079.html">鳳凰山</a></td>
+							<td>☆☆</td>
+							<td>☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>2840m</td>
+						</tr>
+						<tr>
+							<td>028</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-028.html">武尊山</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/north-kanto_oze_nikko.html">上州</a></td>
+							<td>2158m</td>
+						</tr>
+						<tr>
+							<td>041</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-041.html">高妻山</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2353m</td>
+						</tr>
+						<tr>
+							<td>088</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-088.html">荒島岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">北陸</a></td>
+							<td>1524m</td>
+						</tr>
+						<tr>
+							<td>096</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-096.html">祖母山</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>日帰り</td>
+							<td><a href="hundred_mt_area_data/kyusyu.html">九州</a></td>
+							<td>1756m</td>
+						</tr>
+						<tr>
+							<td>020</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-020.html">吾妻山</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>2035m</td>
+						</tr>
+						<tr>
+							<td>033</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-033.html">越後駒ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/joshin-etsu.html">上信越</a></td>
+							<td>2003m</td>
+						</tr>
+						<tr>
+							<td>066</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-066.html">笠ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2897m</td>
+						</tr>
+						<tr>
+							<td>073</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-073.html">御嶽山</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">御嶽山</a></td>
+							<td>3067m</td>
+						</tr>
+						<tr>
+							<td>017</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-017.html">朝日連峰</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>1870m</td>
+						</tr>
+						<tr>
+							<td>056</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-056.html">鹿島槍ヶ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2890m</td>
+						</tr>
+						<tr>
+							<td>061</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-061.html">水晶岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2978m</td>
+						</tr>
+						<tr>
+							<td>062</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-062.html">鷲羽岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2924m</td>
+						</tr>
+						<tr>
+							<td>080</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-080.html">北岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>3192m</td>
+						</tr>
+						<tr>
+							<td>081</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-081.html">間ノ岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>3189m</td>
+						</tr>
+						<tr>
+							<td>082</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-082.html">塩見岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>3047m</td>
+						</tr>
+						<tr>
+							<td>083</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-083.html">悪沢岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>3141m</td>
+						</tr>
+						<tr>
+							<td>084</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-084.html">赤石岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>3120m</td>
+						</tr>
+						<tr>
+							<td>086</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-086.html">光岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>2591m</td>
+						</tr>
+						<tr>
+							<td>060</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-060.html">黒部五郎岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>3泊4日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2840m</td>
+						</tr>
+						<tr>
+							<td>085</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-085.html">聖岳</a></td>
+							<td>☆☆</td>
+							<td>☆☆☆</td>
+							<td>3泊4日</td>
+							<td><a href="hundred_mt_area_data/south-alps.html">南アルプス</a></td>
+							<td>3013m</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addpc1">
+				<!--全頂 PC コンテンツ 3-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="1912487266"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addsp1">
+				<!--全頂 SP コンテンツ 3-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="2455067264"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<div class="htit10"><div>
+				<h3 class="cen">
+					難易度順 一覧表（☆☆☆）
+				</h3>
+			</div></div>
+			<p class="sctate">（この表は横にスクロールできます）</p>
+			<div class="tacon1">
+				<table>
+					<colgroup><col class="top" span="1"></colgroup>
+					<colgroup><col class="nam" span="1"></colgroup>
+					<colgroup><col class="dif" span="1"></colgroup>
+					<colgroup><col class="sta" span="1"></colgroup>
+					<colgroup><col class="iti" span="1"></colgroup>
+					<colgroup><col class="are" span="1"></colgroup>
+					<colgroup><col class="sea" span="1"></colgroup>
+					<thead>
+						<tr>
+							<th>No.</th>
+							<th>山名</th>
+							<th>難易度<br>(3段階)</th>
+							<th>体力度<br>(3段階)</th>
+							<th>参考日程</th>
+							<th>エリア</th>
+							<th>標高</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>054</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-054.html">白馬岳</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2932m</td>
+						</tr>
+						<tr>
+							<td>057</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-057.html">剱岳</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2999m</td>
+						</tr>
+						<tr>
+							<td>075</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-075.html">空木岳</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>1泊2日</td>
+							<td><a href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">中央アルプス</a></td>
+							<td>2864m</td>
+						</tr>
+						<tr>
+							<td>019</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-019.html">飯豊連峰</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/tohoku.html">東北</a></td>
+							<td>2105m</td>
+						</tr>
+						<tr>
+							<td>055</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-055.html">五竜岳</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>2814m</td>
+						</tr>
+						<tr>
+							<td>063</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-063.html">槍ヶ岳</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>3180m</td>
+						</tr>
+						<tr>
+							<td>064</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-064.html">穂高岳</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/north-alps.html">北アルプス</a></td>
+							<td>3190m</td>
+						</tr>
+						<tr>
+							<td>100</td>
+							<td><a href="hundred_mt_individually_data/basic_data/basic_data-100.html">宮之浦岳</a></td>
+							<td>☆☆☆</td>
+							<td>☆☆☆</td>
+							<td>2泊3日</td>
+							<td><a href="hundred_mt_area_data/kyusyu.html">九州</a></td>
+							<td>1936m</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<!-- ↓サイト告知↓ -->
+			<p class="con4">
+				<a href="https://kanto-fureai.net/"><img src="https://kanto-fureai.net/img/title/top.png" style="max-width:100%; height:auto;"></a><br><br>
+				<a href="https://kanto-fureai.net/">
+					ウォーキングコース、ハイキングコース、登山コースなどのバリエーションに富んだ「関東ふれあいの道（首都圏自然歩道）」の完全踏破を応援するサイトをリリースしました
+				</a>
+			</p>
+			<p class="con4">
+				<a href="https://34navi.net/"><img src="https://34navi.net/img/title/top.png" style="max-width:100%; height:auto;"></a><br><br>
+				<a href="https://34navi.net/">
+					秩父の観光旅行におすすめの、日本百番観音に数えられる「秩父三十四ヶ所観音霊場」の秩父札所巡り（お遍路）をサポートするサイトをリリースしました
+				</a>
+			</p>
+			<!-- ↑サイト告知↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="add1">
+				<!--全頂 PC・SP 関連コンテンツユニット-->
+				<ins class="adsbygoogle"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="1479156465"
+					data-ad-format="autorelaxed"></ins>
+				<script>
+				(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓エンドメニュー↓-->
+			<nav>
+			<div class="mainmenu1">
+				<a class="bttlink1" href="hundred_mt_list_data/list.html">日本百名山 一覧</a>
+				<a class="bttlink1" href="hundred_mt_list_data/japanese_syllabary.html">五十音順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/sea_level.html">標高順</a>
+				<div class="bttlink1">難易度順</div>
+				<a class="bttlink1" href="hundred_mt_list_data/stamina.html">体力度順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/course_time.html">参考タイム順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/itinerary.html">参考日程順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/season.html">登山適期順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/colored_leaves.html">紅葉時期順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/snow_season.html">積雪期・残雪期 一覧</a>
+				<a class="bttlink1" href="hundred_mt_list_data/volcano.html">活火山指定 一覧</a>
+			</div>
+			</nav>
+			<!--↑エンドメニュー↑-->
+			<!--↓スマホ用ナビゲーション↓-->
+			<nav>
+			<div class="spmenu1">
+				<div id="spmenuin1">
+					<a class="bttlink1" href="javascript:SpMenuCon( 'on2' )"><p>&equiv;</p></a>
+				</div>
+				<div id="spmenuin2">
+					<a class="bttlink1" href="hundred_mt_list_data/list.html">日本百名山 一覧</a>
+					<a class="bttlink1" href="hundred_mt_list_data/japanese_syllabary.html">五十音順</a>
+					<a class="bttlink1" href="hundred_mt_list_data/sea_level.html">標高順</a>
+					<div class="bttlink1">難易度順</div>
+					<a class="bttlink1" href="hundred_mt_list_data/stamina.html">体力度順</a>
+					<a class="bttlink1" href="hundred_mt_list_data/course_time.html">参考タイム順</a>
+					<a class="bttlink1" href="hundred_mt_list_data/itinerary.html">参考日程順</a>
+					<a class="bttlink1" href="hundred_mt_list_data/season.html">登山適期順</a>
+					<a class="bttlink1" href="hundred_mt_list_data/colored_leaves.html">紅葉時期順</a>
+					<a class="bttlink1" href="hundred_mt_list_data/snow_season.html">積雪期・残雪期 一覧</a>
+					<a class="bttlink1" href="hundred_mt_list_data/volcano.html">活火山指定 一覧</a>
+				</div>
+				<div id="spmenuin3">
+					<a class="bttlink1" href="hundred_mt_area_data/hokkaido.html">北海道</a>
+					<a class="bttlink1" href="hundred_mt_area_data/tohoku.html">東北</a>
+					<a class="bttlink1" href="hundred_mt_area_data/north-kanto_oze_nikko.html">北関東・尾瀬・日光</a>
+					<a class="bttlink1" href="hundred_mt_area_data/joshin-etsu.html">上信越</a>
+					<a class="bttlink1" href="hundred_mt_area_data/chichibu_tama_south-kanto.html">秩父・多摩・南関東</a>
+					<a class="bttlink1" href="hundred_mt_area_data/north-alps.html">北アルプス</a>
+					<a class="bttlink1" href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">美ヶ原・八ヶ岳・中央アルプス</a>
+					<a class="bttlink1" href="hundred_mt_area_data/south-alps.html">南アルプス</a>
+					<a class="bttlink1" href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">北陸・近畿・中国・四国</a>
+					<a class="bttlink1" href="hundred_mt_area_data/kyusyu.html">九州</a>
+				</div>
+				<div id="spmenuin4">
+					<a class="bttlink1" href="index.html">日本百名山</a>
+					<a class="bttlink1" href="index_200.html">日本二百名山</a>
+					<a class="bttlink1" href="index_300.html">日本三百名山</a>
+					<a class="bttlink1" href="index_low.html">日本百低山</a>
+					<a class="bttlink1" href="index_1000.html">日本千名山</a>
+				</div>
+				<div id="spmenuin5">
+					<div id="menubtt1"><a class="bttlink1" href="javascript:SpMenuCon( 'off' )"><p>閉</p></a></div>
+					<div id="menubtt2"><a class="bttlink1" href="javascript:SpMenuCon( 'on2' )"><p id="bttintext2">条件<br>一覧</p></a></div>
+					<div id="menubtt3"><a class="bttlink1" href="javascript:SpMenuCon( 'on3' )"><p id="bttintext3">ｴﾘｱ<br>一覧</p></a></div>
+					<div id="menubtt4"><a class="bttlink1" href="javascript:SpMenuCon( 'on4' )"><p id="bttintext4">名山<br>TOP</p></a></div>
+					<div id="menubtt5"><a class="bttlink1" href="index.html"><p id='bttintext5'>TOP<br>ﾍﾟｰｼﾞ</p></a></div>
+				</div>
+			</div>
+			</nav>
+			<!--↑スマホ用ナビゲーション↑-->
+		</div>
+		<!--↑メインカラム↑-->
+		<!--↓サブカラム↓-->
+		<div class="subcolumn">
+			<!--↓サイト内検索↓-->
+			<nav>
+			<div class="htit3">
+				<h1>
+					サイト内検索
+				</h1>
+			</div>
+			<div class="search1">
+				<script async src="https://cse.google.com/cse.js?cx=partner-pub-8903398808176240:nnafynj36qt"></script>
+				<div class="gcse-search"></div>
+			</div>
+			<div class="submenu1">
+				<a class="bttlink1" href="index.html">日本百名山登山支援 全頂制覇百名山 TOP</a>
+				<a class="bttlink1" href="javascript:history.back()">前のページに戻る</a>
+			</div>
+			</nav>
+			<!--↑サイト内検索↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addpc1">
+				<!--全頂 PC サイド 1 ロング-->
+				<ins class="adsbygoogle res_none_max-01"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="9638143667"
+					data-ad-format="vertical,rectangle"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓日本百名山 条件別一覧表↓-->
+			<div class="htit3">
+				<h1>
+					日本百名山 条件別一覧表
+				</h1>
+			</div>
+			<div class="submenu01">
+				<a class="bttlink1" href="hundred_mt_list_data/list.html">日本百名山 一覧</a>
+				<a class="bttlink1" href="hundred_mt_list_data/japanese_syllabary.html">五十音順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/sea_level.html">標高順</a>
+				<div class="bttlink1">難易度順</div>
+				<a class="bttlink1" href="hundred_mt_list_data/stamina.html">体力度順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/course_time.html">参考タイム順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/itinerary.html">参考日程順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/season.html">登山適期順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/colored_leaves.html">紅葉時期順</a>
+				<a class="bttlink1" href="hundred_mt_list_data/snow_season.html">積雪期・残雪期 一覧</a>
+				<a class="bttlink1" href="hundred_mt_list_data/volcano.html">活火山指定 一覧</a>
+			</div>
+			<!--↑日本百名山 条件別一覧表↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addpc1">
+				<!--全頂 PC サイド 2-->
+				<ins class="adsbygoogle res_none_max-01"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="6245507247"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓日本百名山 エリア別一覧↓-->
+			<div class="htit3">
+				<h1>
+					日本百名山 エリア別一覧
+				</h1>
+			</div>
+			<div class="submenu01">
+				<a class="bttlink1" href="hundred_mt_area_data/hokkaido.html">北海道</a>
+				<a class="bttlink1" href="hundred_mt_area_data/tohoku.html">東北</a>
+				<a class="bttlink1" href="hundred_mt_area_data/north-kanto_oze_nikko.html">北関東・尾瀬・日光</a>
+				<a class="bttlink1" href="hundred_mt_area_data/joshin-etsu.html">上信越</a>
+				<a class="bttlink1" href="hundred_mt_area_data/chichibu_tama_south-kanto.html">秩父・多摩・南関東</a>
+				<a class="bttlink1" href="hundred_mt_area_data/north-alps.html">北アルプス</a>
+				<a class="bttlink1" href="hundred_mt_area_data/utsukushigahara_yatsugatake_central-alps.html">美ヶ原・八ヶ岳・中央アルプス</a>
+				<a class="bttlink1" href="hundred_mt_area_data/south-alps.html">南アルプス</a>
+				<a class="bttlink1" href="hundred_mt_area_data/hokuriku_kinki_tyugoku_shikoku.html">北陸・近畿・中国・四国</a>
+				<a class="bttlink1" href="hundred_mt_area_data/kyusyu.html">九州</a>
+			</div>
+			<!--↑日本百名山 エリア別一覧↑-->
+			<!--↓Ads by Google↓-->
+			<aside>
+			<div class="addpc1">
+				<!--全頂 PC サイド 3-->
+				<ins class="adsbygoogle res_none_max-01"
+					style="display:block"
+					data-ad-client="ca-pub-8903398808176240"
+					data-ad-slot="1251382623"
+					data-ad-format="auto"
+					data-full-width-responsive="true"></ins>
+				<script>
+					(adsbygoogle = window.adsbygoogle || []).push({});
+				</script>
+			</div>
+			</aside>
+			<!--↑Ads by Google↑-->
+			<!--↓日本の名山 TOP↓-->
+			<div class="htit3">
+				<h1>
+					日本の名山 TOP
+				</h1>
+			</div>
+			<div class="submenu01">
+				<a class="bttlink1" href="index.html">日本百名山</a>
+				<a class="bttlink1" href="index_200.html">日本二百名山</a>
+				<a class="bttlink1" href="index_300.html">日本三百名山</a>
+				<a class="bttlink1" href="index_low.html">日本百低山</a>
+				<a class="bttlink1" href="index_1000.html">日本千名山</a>
+			</div>
+			<!--↑日本の名山 TOP↑-->
+			<!--↓お知らせ↓-->
+			<nav>
+			<div class="htit3">
+				<h1>
+					お知らせ
+				</h1>
+			</div>
+			<div class="submenu01">
+				<a class="bttlink1" href="others/attention.html">ご注意</a>
+				<a class="bttlink1" href="others/guide.html">表の見方</a>
+				<a class="bttlink1" href="others/link_method.html">リンクについて</a>
+				<a class="bttlink1" href="sitemap.html">サイトマップ</a>
+				<a class="bttlink1" href="others/update_information.html">更新情報</a>
+				<a class="bttlink1" href="others/support/mpmail_01/form.html">管理者にメール</a>
+				<a class="bttlink1" href="https://www.facebook.com/inpossi" target="_blank">Inpossi 公式フェイスブック</a>
+			</div>
+			</nav>
+			<!--↑お知らせ↑-->
+			<!--↓Presented by Inpossi↓-->
+			<nav>
+			<div class="htit3">
+				<h1>
+					Presented by Inpossi
+				</h1>
+			</div>
+			<div class="submenu1">
+				<a class="bttlink1" href="https://kanto-fureai.net/" target="_blank">関東ふれあいのみち 関ふれNAVI</a>
+				<a class="bttlink1" href="https://34navi.net/" target="_blank">秩父三十四ヶ所観音霊場 秩父お遍路NAVI</a>
+			</div>
+			</nav>
+			<!--↑Presented by Inpossi↑-->
+		</div>
+		<!--↑サブカラム↑-->
+		<!--↓Ads by Google↓-->
+		<div class="addpcst1">
+			<aside>
+			<!--全頂 PC サイド エンド ロング-->
+			<ins class="adsbygoogle"
+				style="display:block"
+				data-ad-client="ca-pub-8903398808176240"
+				data-ad-slot="8098621660"
+				data-ad-format="vertical,rectangle"
+				data-full-width-responsive="true"></ins>
+			<script>
+				 (adsbygoogle = window.adsbygoogle || []).push({});
+			</script>
+			</aside>
+		</div>
+		<!--↑Ads by Google↑-->
+	</div>
+	<!-- ↑ミドルボックス↑ -->
+	</article>
+	</main>
+	<!--↑メイン↑-->
+	<!--↓フッター↓-->
+	<footer>
+	<!--↓著作権表示↓-->
+	<img src="gazo/title/copyright.gif" alt="Copyright(C) Inpossi All rights reserved" title="Copyright(C) Inpossi All rights reserved">
+	<!--↑著作権表示↑-->
+	</footer>
+	<!--↑フッター↑-->
+</div>
+<!--↑バック↑-->
+<!--↓アクセス解析↓-->
+<script>
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	ga('create', 'UA-6294431-1', 'auto');
+	ga('send', 'pageview');
+
+</script>
+<!--↑アクセス解析↑-->
+</body>
+</html>

--- a/scrape_mountain_level.rb
+++ b/scrape_mountain_level.rb
@@ -1,0 +1,45 @@
+require 'nokogiri'
+
+html = open('mountain_level.html').read
+doc = Nokogiri::HTML.parse(html)
+
+# pp doc.at_css('h1') # 条件に合う要素が1つだけの場合
+# pp doc.at_css('#through') # CSSセレクタらしくidで指定
+# pp doc.at_css('.under') # classで指定。条件に合う最初の要素を取得
+# pp doc.at_css('body > div:nth-child(3)') # nth-childも使える
+# pp doc.at_css('body > h2:nth-of-type(3)') # nth-of-typeも使える
+# pp doc.at_css('h1').class # 戻り値のクラスを確認
+# pp doc.at_css('.hogehoge') # 条件に合う要素が存在しない場合
+
+# 全ての行を取得
+# pp doc.css('.tacon1 tbody tr')
+# 行を取得
+# pp doc.at_css('.tacon1 tbody tr')
+# 次の行を取得
+# pp doc.at_css('.tacon1 tbody tr').next_element
+# => doc.at_css('.tacon1 tbody tr').at_css('td').parent　と同じ
+# pp doc.at_css('.tacon1 tbody tr').at_css('td')
+# pp doc.at_css('.tacon1 tbody tr').css('td')
+# pp doc.at_css('.tacon1 tbody tr').css('a')
+# pp doc.at_css('.tacon1 tbody tr').css('a').attribute('href')
+# pp doc.at_css('.tacon1 tbody tr').css('a').children
+# pp doc.at_css('.tacon1 tbody tr').at_css('a').children.first.text
+# => "八幡平"
+# data = doc.at_css('.tacon1 tbody tr').css('td').children
+# data.each do |d|
+#   if d.text == '日帰り'
+#     pp d.parent.parent.at_css('a').children.first.text
+#   end
+# end
+# pp doc.css('.tacon1 tbody').at_css('tr')
+
+# 全ての行を取得し、各行を評価
+data = doc.css('.tacon1 tbody tr')
+data.each do |d|
+  # 行の「山の名前」の取得
+  name = d.at_css('a').children.first.text
+  # 行の「難易度」の取得
+  puts "#{name}: hard" if d.at_css('a').parent.next_element.text == "★★★★" || d.at_css('a').parent.next_element.text == "☆☆☆"
+  puts "#{name}: normal" if d.at_css('a').parent.next_element.text == "★★★" || d.at_css('a').parent.next_element.text == "☆☆"
+  puts "#{name}: easy" if d.at_css('a').parent.next_element.text == "★★" || d.at_css('a').parent.next_element.text == "☆"
+end


### PR DESCRIPTION
## 概要

山テーブルにlevelカラムを追加、スクレイピングでDBにデータを保存

## コメント

登山における難易度は登山ルートによっても異なるため、本来であればコース情報も入れた上で難易度を表示するのが正確ではあるが、コース情報を入れるのには時間がかかりすぎるので、一旦山ごとの難易度を入力。
今後の機能追加でコース情報も加えていく。

#52 