### PR TITLE
修正:山の詳細ページ内googlemapから該当の山のピンを削除

### DIFF
--- a/app/controllers/mountains_controller.rb
+++ b/app/controllers/mountains_controller.rb
@@ -9,8 +9,9 @@ class MountainsController < ApplicationController
   end
 
   def show
-    @mountains_on_map = Mountain.all
     @mountain = Mountain.find(params[:id])
+    # 詳細画面では該当する山のピンは立てない。
+    @mountains_on_map = Mountain.where.not(id: @mountain.id)
     # 標高条件をクリアする服装パターンのうち、
     # ① 上限標高(max_elevation)が低い服装パターン順に並べ替える。
     # ② さらに、下限気温(lower_limit_temp)が高い服装パターン順に並べ替えて、先頭２つを取得する（季節が「春秋」か「夏」の２パターンのため）。

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -55,9 +55,9 @@
         <h2>地図から探す</h2>
             <!-- Featured Map Row-->
             <div class="row gx-0 mb-4 mb-lg-5 px-5 align-items-center">
-                    <!-- googlemapを埋め込む場所　-->
-                    <input id="pac-input" class="form-control" type="text" placeholder="キーワード" />
-                    <div id='googlemap' style="height:420px" class='mb-3 mb-lg-0 rounded-4'></div>
+                <!-- googlemapを埋め込む場所　-->
+                <input id="pac-input" class="form-control" type="text" placeholder="キーワード" />
+                <div id='googlemap' style="height:420px" class='mb-3 mb-lg-0 rounded-4'></div>
             </div>
         </div>
     </section>   
@@ -152,7 +152,7 @@
         // マーカーに表示する内容を設定
         var contentStr = 
             '<div name="marker" class="map">' +
-            '<a href="/mountains/' + markerData[i]['id'] + '">' +
+            '<a href="/mountains/' + markerData[i]['id'] + '" data-turbolinks="false">' +
             markerData[i]['name'] +
             '</a>' +
             '</div>'

--- a/app/views/mountains/show.html.erb
+++ b/app/views/mountains/show.html.erb
@@ -104,7 +104,6 @@ let markerData = []
     };
     markerData.push(obj)
 <% end %>
-let geocoder
 
 // 「InvalidValueError: initMap is not a function」への対策
 window.onload = function () {
@@ -112,9 +111,6 @@ window.onload = function () {
 }
 
 function initMap(){
-    // geocoderを初期化
-    geocoder = new google.maps.Geocoder()
-
     // 地図の作成、中心位置の設定
     map = new google.maps.Map(document.getElementById('googlemap'), {
     center: { lat: <%= @mountain.peak_location_lat %>, lng: <%= @mountain.peak_location_lng %> }, // 日本の中心に緯度経度を設定
@@ -131,12 +127,14 @@ function initMap(){
 
     // マーカーに表示する内容を設定
     var contentStr = 
-        '<div name="marker" class="map">' +
-        '<a href="/mountains/' + markerData[i]['id'] + '">' +
+        '<div name="marker" class="map">' + 
+        '<a href="/mountains/' + markerData[i]['id'] + '" data-turbolinks="false">' +
         markerData[i]['name'] +
         '</a>' +
         '</div>'
         ;
+
+   
 
     // 吹き出しの追加
     infoWindow[i] = new google.maps.InfoWindow({
@@ -157,25 +155,6 @@ function markerEvent(i) {
     currentInfoWindow = infoWindow[i]
     });
 }
-
-function codeAddress(){
-    // 入力を取得
-    let inputAddress = document.getElementById('address').value;
-
-    // geocodingしたあとmapを移動
-    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
-    if (status == 'OK') {
-        // map.setCenterで地図が移動
-        map.setCenter(results[0].geometry.location);
-        map.setZoom(10);
-    } else {
-        alert('Geocode was not successful for the following reason: ' + status);
-    }
-    });
-}
-
-
-
 
 
 <!-- 天気予報-->


### PR DESCRIPTION
## 概要

山の詳細ページにてリンク付きの吹き出しを表示するためのピンを立てていたが、
詳細ページから詳細ページへのリンクを貼っても意味がないため、削除。
ただし、他の山のピンは残している。

## コメント

googlemapアプリに遷移するリンクを吹き出し内に追記してピンを残したままでも良かったが、
遷移後のgooglemapでの表示が経度緯度での表示になってしまう。これでもいいが、旨味があまりない。
googlemap embed apiなどを使ってgooglemapのデータベースへアクセスできれば、遷移後にgooglemapが保有する画像や口コミなども参照でき旨みが大きいが、それを正確に実装するにはplaceIDが必要なため実装には時間が必要。
実装は今後検討する。
なお、placeIDはデータ取得後、無期限で保有ができるようなので山テーブルの属性に追加するのもありだと思う。
https://developers.google.com/maps/documentation/places/web-service/policies?_ga=2.256286347.1216429806.1628743710-1295601024.1623232752&_gac=1.126111359.1625839084.CjwKCAjw55-HBhAHEiwARMCszjB4Ajbsuz0zfxEblkrYZgcGYTFsk-t3o0ueFsrgexZ-92rrTnOB8xoCioUQAvD_BwE
placeIDは場合によって変更されることもあるが、山なので基本的には変更されないと思われる。
（一般的に変更されるパターンは「閉店」もしくは「移転」）