### PR TITLE
トップページに話題の山の表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,6 @@ gem 'nokogiri'
 gem 'jp_prefecture'
 gem 'Hyakumeizan'
 
+# 内部でwheneverを使うわけではないため、Railsの実行時に読み込まないようにする
+gem 'whenever', require: false
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     childprocess (3.0.0)
+    chronic (0.10.2)
     code_analyzer (0.5.2)
       sexp_processor
     coderay (1.1.3)
@@ -322,6 +323,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -366,6 +369,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)
+  whenever
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -4,5 +4,7 @@ class HomesController < ApplicationController
   def top
     @mountains = @q.result(distinct: true)
     @area = %w(北海道 東北 関東 中部 関西 四国 中国 九州)
+    # #山の名前で投稿された画像付きツイートが多い順に並べ替えてtop６を取得
+    @recommended_mountains = @mountains.order(twitter_result_count: :desc).first(6)
   end
 end

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -60,7 +60,20 @@
                 <div id='googlemap' style="height:420px" class='mb-3 mb-lg-0 rounded-4'></div>
             </div>
         </div>
-    </section>   
+    </section>
+
+    <!-- Index-->
+    <section class="page-section">
+        <div class="container px-4 px-lg-5">
+        <h2 class="mb-2">話題の山 on twitter</h2>
+        <p class="mb-4">過去１週間、最も多くツイートされた山を表示しています</p>
+            <div class="row">
+                <% if @recommended_mountains.present? %>
+                    <%= render @recommended_mountains %>
+                <% end %>
+            </div>
+        </div>
+    </section>
 
     <script>
     let map

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,18 @@
+# 詳細はgithub参照
+# https://github.com/javan/whenever/blob/main/README.md#example-schedulerb-file
+# Rails.rootを使用するために必要。wheneverは読み込まれるときにrailsを起動する必要がある
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+
+# cronを実行する環境変数をセット
+set :environment, rails_env
+
+# cronのログの吐き出し場所。ここでエラー内容を確認する
+set :output, "#{Rails.root}/log/cron.log"
+
+# 毎週月曜日にmountainテーブルのtwitter_result_countを更新する。
+every :monday, at: '3:00 am' do
+  rake 'mountain_contents:search_tweets_counts_by_hashtag'
+end

--- a/db/migrate/20210815083230_add_details_to_mountains.rb
+++ b/db/migrate/20210815083230_add_details_to_mountains.rb
@@ -1,0 +1,5 @@
+class AddDetailsToMountains < ActiveRecord::Migration[6.0]
+  def change
+    add_column :mountains, :twitter_result_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_06_023402) do
+ActiveRecord::Schema.define(version: 2021_08_15_083230) do
 
   create_table "courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2021_08_06_023402) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "level"
+    t.integer "twitter_result_count", default: 0, null: false
   end
 
   create_table "outfits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/lib/tasks/enrich_mountain_contents.rake
+++ b/lib/tasks/enrich_mountain_contents.rake
@@ -5,11 +5,17 @@ namespace :enrich_mountain_contents do
     bearer_token = ENV["TWITTER_BEARER_TOKEN"]
     search_url = "https://api.twitter.com/2/tweets/search/recent"
 
+    # 山の取得件数
+    number = 
+
     twitter_image_urls = {}
-    Mountain.first(2).each do |mountain|
+    Mountain.first(number).each do |mountain|
+      # リクエスト上限が450回/15分 = 1回/2秒なのでsleep2以上は入れとく。
       sleep 3
+      # クエリの組み立て方について https://developer.twitter.com/en/docs/twitter-api/tweets/search/integrate/build-a-query
       query = "##{mountain.name} has:images"
 
+      # クエリのパラメータについて https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-recent
       query_params = {
         "query": query, # 必須
         "max_results": 20, #10~100で選択。デフォルトは10
@@ -41,8 +47,51 @@ namespace :enrich_mountain_contents do
 
       twitter_image_urls[:"#{mountain.name}"] = media_urls
 
-      # 取得したapiデータをどう取り扱うのか検討中（DBに保存するのはよくない？）
       puts twitter_image_urls
+    end
+  end
+
+  desc "過去１週間で「#山の名前」で投稿されたツイート件数を取得し、保存する"
+  task search_tweets_counts_by_hashtag: :environment do
+    bearer_token = ENV["TWITTER_BEARER_TOKEN"]
+    search_url = "https://api.twitter.com/2/tweets/search/recent"
+    # 山の取得件数
+    number = 100
+
+    Mountain.first(number).each do |mountain|
+      sleep 3
+      # 画像付きツイートを取得。has:imagesとしているのは
+      # 実際に行っている人（写真が添付されている＝現地に行った、という前提）がどれくらいの数いるのかを取得したいため。
+      query = "##{mountain.name} has:images"
+
+      query_params = {
+        "query": query, # 必須
+        "max_results": 100, #10~100で選択。デフォルトは10
+        # "start_time": "2020-07-01T00:00:00Z",
+        # "end_time": "2020-07-02T18:00:00Z",
+        # "expansions": "attachments.poll_ids,attachments.media_keys,author_id",
+        # "tweet.fields": "attachments,author_id,conversation_id,created_at,entities,id,lang"
+        # "user.fields": "description",
+        # "media.fields": "url", #expansionsのattachments.media_keysをリクエストに含めないと取得できない。
+        # "place.fields": "country_code",
+        # "poll.fields": "options"
+      }
+
+      options = {
+        method: 'get',
+        headers: {
+          "User-Agent": "v2RecentSearchRuby",
+          "Authorization": "Bearer #{bearer_token}"
+        },
+        params: query_params
+      }
+    
+      request = Typhoeus::Request.new(search_url, options)
+      response = request.run
+      mountain_count = JSON.parse(response.body)['meta']['result_count']
+
+      mountain.update!(twitter_result_count: mountain_count)
+      puts "#{mountain.name}: #{mountain.twitter_result_count}件"
     end
   end
 

--- a/lib/tasks/enrich_mountain_contents.rake
+++ b/lib/tasks/enrich_mountain_contents.rake
@@ -1,4 +1,4 @@
-namespace :enrich_mountain_contents do
+namespace :mountain_contents do
 
   desc "過去１週間で「#山の名前」で投稿されたツイートを取得し、画像urlを抽出する"
   task search_tweets_by_hashtag: :environment do
@@ -267,6 +267,5 @@ namespace :enrich_mountain_contents do
       end
     end
   end
-
 
 end


### PR DESCRIPTION
## 概要

おすすめ機能の実装
→ twitterAPIを使って過去一週間にハッシュタグでツイートされた件数が多い順で表示する。

1. 山テーブルにtwitter_result_count属性を追加
2. TwitterAPI経由で過去一週間に「#山の名前」でツイートされた件数を各山ごとに取得し、twitter_result_countに保存
3. トップページにてtwitter_result_countが最も多い山を6つ表示
4. wheneverのrakeタスクでパッチを回し、毎週月曜日に2を実行

## コメント

おすすめ方法自体のロジックに改善の余地あり。
→上位の山は大体おんなじような結果になる。
また、過去一週間分しか見れないので季節によってはツイート件数０の山がザラに出てくることも考えられる。

#48 