### PR TITLE
修正:package.jsonのwebpack-cliをdependenciesへ移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "^5.4.0",
     "jquery": "^3.6.0",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "webpack-cli": "^4.8.0"
   },
   "version": "0.1.0",
   "devDependencies": {
     "webpack": "4.x.x",
-    "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,10 +1149,10 @@
   dependencies:
     envinfo "^7.7.3"
 
-"@webpack-cli/serve@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.1.tgz"
-  integrity sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==
+"@webpack-cli/serve@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.2.tgz#ea584b637ff63c5a477f6f21604b5a205b72c9ec"
+  integrity sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -6826,15 +6826,15 @@ webpack-cli@^3.3.12:
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
 
-webpack-cli@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.2.tgz"
-  integrity sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==
+webpack-cli@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.8.0.tgz#5fc3c8b9401d3c8a43e2afceacfa8261962338d1"
+  integrity sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
     "@webpack-cli/configtest" "^1.0.4"
     "@webpack-cli/info" "^1.3.0"
-    "@webpack-cli/serve" "^1.5.1"
+    "@webpack-cli/serve" "^1.5.2"
     colorette "^1.2.1"
     commander "^7.0.0"
     execa "^5.0.0"


### PR DESCRIPTION
## 概要

修正:package.jsonのwebpack-cliをdevDependenciesからdependenciesへ移動


## コメント

- dependencies：本番環境でも利用するパッケージやその依存関係
- devDependencies：開発環境やテスト環境で利用するパッケージやその依存関係。本番用のビルドをするときに含まれない。

[webpack-cli公式](https://github.com/webpack/webpack-cli)では、
yarn add webpack-cli --dev
devDependenciesへの追加になっていてこれで追加したために、devDependenciesへ記載されていた

#95