### PR TITLE
修正:herokuデプロイ時のエラー修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.3-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -331,6 +333,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   Hyakumeizan


### PR DESCRIPTION
## 概要

herokuデプロイ時にエラー
```
 Failed to install gems via Bundler.
```

エラーログ記載の
```
logBundler Output: Your bundle only supports platforms ["x86_64-darwin-20"] but your local platform
is x86_64-linux. Add the current platform to the lockfile with `bundle lock
--add-platform x86_64-linux` and try again.
```
から以下を実施

$ bundle lock --add-platform x86_64-linux
